### PR TITLE
Allow configuring OpenAI endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 OPENAI_API_KEY=x
+OPENAI_API_BASE=https://api.openai.com/v1
 DISCORD_BOT_TOKEN=x
 DISCORD_CLIENT_ID=x
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This bot uses the [OpenAI Python Library](https://github.com/openai/openai-pytho
 
 1. Copy `.env.example` to `.env` and start filling in the values as detailed below
 1. Go to https://beta.openai.com/account/api-keys, create a new API key, and fill in `OPENAI_API_KEY`
+1. (Optional) Set `OPENAI_API_BASE` to the API endpoint you want the bot to use. Defaults to `https://api.openai.com/v1`
 1. Create your own Discord application at https://discord.com/developers/applications
 1. Go to the Bot tab and click "Add Bot"
     - Click "Reset Token" and fill in `DISCORD_BOT_TOKEN`

--- a/src/completion.py
+++ b/src/completion.py
@@ -9,6 +9,7 @@ from src.constants import (
     BOT_INSTRUCTIONS,
     BOT_NAME,
     EXAMPLE_CONVOS,
+    OPENAI_API_BASE,
 )
 import discord
 from src.base import Message, Prompt, Conversation, ThreadConfig
@@ -38,7 +39,7 @@ class CompletionData:
     status_text: Optional[str]
 
 
-client = AsyncOpenAI()
+client = AsyncOpenAI(base_url=OPENAI_API_BASE)
 
 
 async def generate_completion_response(

--- a/src/constants.py
+++ b/src/constants.py
@@ -22,6 +22,7 @@ EXAMPLE_CONVOS = CONFIG.example_conversations
 DISCORD_BOT_TOKEN = os.environ["DISCORD_BOT_TOKEN"]
 DISCORD_CLIENT_ID = os.environ["DISCORD_CLIENT_ID"]
 OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+OPENAI_API_BASE = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
 DEFAULT_MODEL = os.environ["DEFAULT_MODEL"]
 
 ALLOWED_SERVER_IDS: List[int] = []

--- a/src/moderation.py
+++ b/src/moderation.py
@@ -4,10 +4,11 @@ from src.constants import (
     SERVER_TO_MODERATION_CHANNEL,
     MODERATION_VALUES_FOR_BLOCKED,
     MODERATION_VALUES_FOR_FLAGGED,
+    OPENAI_API_BASE,
 )
 from openai import OpenAI
 
-client = OpenAI()
+client = OpenAI(base_url=OPENAI_API_BASE)
 from typing import Optional, Tuple
 import discord
 from src.utils import logger


### PR DESCRIPTION
## Summary
- allow overriding the OpenAI API endpoint via `OPENAI_API_BASE`
- hook the new variable up to the OpenAI clients
- document the new variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68689130629c83318ba194f3774356e5